### PR TITLE
Remove ext-soap as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     ],
     "license": "MIT",
     "require": {
-        "ext-soap": "*",
         "php": "^8.0",
         "sylius/sylius": "~1.12.0",
         "friendsofsymfony/ckeditor-bundle": "^2.4"


### PR DESCRIPTION
Hi,

Thanks for the plugin !

I noticed it requires ext-soap in composer.json but it seems like its not used in this project.